### PR TITLE
Auto-disable auto mode manually setting air alarm mode

### DIFF
--- a/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
+++ b/Content.Server/Atmos/Monitor/Systems/AirAlarmSystem.cs
@@ -298,6 +298,7 @@ public sealed class AirAlarmSystem : EntitySystem
             }
 
             _adminLogger.Add(LogType.AtmosDeviceSetting, LogImpact.Medium, $"{ToPrettyString(args.Actor)} changed {ToPrettyString(uid)} mode to {args.Mode}");
+            component.AutoMode = false; // setting a mode manually exits auto mode
             SetMode(uid, addr, args.Mode, false);
         }
         else


### PR DESCRIPTION
Fixes air alarm auto-mode confusion. 

From @Partmedia (modified to preserve burn chamber functionality)